### PR TITLE
(refactor) Mobile layout logic

### DIFF
--- a/src/components/Book/Book.js
+++ b/src/components/Book/Book.js
@@ -6,13 +6,14 @@ import memoizeOne from 'memoize-one'
 import PropTypes from 'prop-types'
 import React, { useMemo, memo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { compose } from 'react-redux'
 
 import * as Classes from '../../common/classes'
 import { DATA_MAPPING } from '../../common/props'
 import withI18nProvider from '../../hoc/withI18nProvider'
+import withMobileLayout from '../../hoc/withMobileLayout'
 import withResponsive from '../../hoc/withResponsive'
 import { getVisibleColumns } from '../../utils/data-mapping'
-import { ResponsiveState } from '../Responsive'
 import Spinner from '../ui/Spinner'
 import getColumns from './Book.columns'
 import {
@@ -37,16 +38,15 @@ export const Book = (props) => {
     cancelOrder,
     onRowClick,
     className,
-    parentWidth,
     zoom,
     bookViz,
     rowMapping,
     isStackedView,
+    isMobileLayout,
     numberOfRows,
   } = props
   const { t } = useTranslation()
-  const { width } = ResponsiveState()
-  const isVertical = _isBoolean(isStackedView) ? isStackedView : (parentWidth || width) < BREAKPOINT_VERTICAL
+  const isVertical = _isBoolean(isStackedView) ? isStackedView : isMobileLayout
   const [oBids, oAsks] = _partition(orders, (o) => o.amount > 0)
 
   const decimals = useMemo(
@@ -177,10 +177,6 @@ Book.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * The parent’s width of the Book’s component.
-   */
-  parentWidth: PropTypes.number,
-  /**
    * The zoom level for bar graph.
    */
   zoom: PropTypes.number,
@@ -217,7 +213,6 @@ export const defaultProps = {
   cancelOrder: () => { },
   onRowClick: () => { },
   className: null,
-  parentWidth: null,
   zoom: DEFAULT_ZOOM,
   bookViz: BOOK_VIZ_TYPES.CUMULATIVE,
   rowMapping: {},
@@ -228,4 +223,9 @@ export const defaultProps = {
 
 Book.defaultProps = defaultProps
 
-export default withI18nProvider(withResponsive(memo(Book)))
+export default compose(
+  withI18nProvider,
+  withResponsive,
+  withMobileLayout(BREAKPOINT_VERTICAL),
+  memo,
+)(Book)

--- a/src/components/MarketList/MarketList.js
+++ b/src/components/MarketList/MarketList.js
@@ -4,14 +4,15 @@ import React, {
   useReducer, useMemo, useCallback, memo,
 } from 'react'
 import { useTranslation } from 'react-i18next'
+import { compose } from 'react-redux'
 
 import { BREAKPOINTS } from '../../common/classes'
 import * as Classes from '../../common/classes'
 import { DATA_MAPPING } from '../../common/props'
 import withI18nProvider from '../../hoc/withI18nProvider'
+import withMobileLayout from '../../hoc/withMobileLayout'
 import withResponsive from '../../hoc/withResponsive'
 import { getMappingForKey, getValue } from '../../utils/data-mapping'
-import { ResponsiveState } from '../Responsive'
 import { Table } from '../ui'
 import { TAB_PROP_TYPE } from '../ui/Tabs/Tab'
 import { getColumns } from './MarketList.columns'
@@ -31,10 +32,8 @@ export const MarketList = (props) => {
     filterData,
     defaultSortBy,
     rowMapping: customMapping,
-    parentWidth,
+    isMobileLayout: isSmallView,
   } = props
-  const { width } = ResponsiveState()
-  const isSmallView = (parentWidth || width) < BREAKPOINTS.SM
 
   const [state, dispatch] = useReducer(reducer, getInitState(tabs, defaultSortBy))
   const searchTerm = _get(state, `filter.${KEYS.BASE_CCY}`)
@@ -150,7 +149,11 @@ MarketList.propTypes = {
   defaultSortBy: PropTypes.string,
   filterData: PropTypes.func,
   rowMapping: PropTypes.objectOf(PropTypes.shape(DATA_MAPPING)),
-  parentWidth: PropTypes.number,
+  /**
+   * If true, show the OrderHistory in a condensed mobile layout. By default
+   * the mobile layout will be enabled when the screen size is below 576.
+   */
+  isMobileLayout: PropTypes.bool,
 }
 
 export const defaultProps = {
@@ -158,9 +161,14 @@ export const defaultProps = {
   filterData: filterDataHelper,
   rowMapping: {},
   onRowClick: () => {},
-  parentWidth: null,
+  isMobileLayout: undefined,
 }
 
 MarketList.defaultProps = defaultProps
 
-export default withI18nProvider(withResponsive(memo(MarketList)))
+export default compose(
+  withI18nProvider,
+  withResponsive,
+  withMobileLayout(BREAKPOINTS.SM),
+  memo,
+)(MarketList)

--- a/src/components/OrderHistory/OrderHistory.js
+++ b/src/components/OrderHistory/OrderHistory.js
@@ -3,13 +3,14 @@ import _get from 'lodash/get'
 import PropTypes from 'prop-types'
 import React, { useMemo, memo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { compose } from 'react-redux'
 
 import * as Classes from '../../common/classes'
 import { DATA_MAPPING } from '../../common/props'
 import withI18nProvider from '../../hoc/withI18nProvider'
+import withMobileLayout from '../../hoc/withMobileLayout'
 import withResponsive from '../../hoc/withResponsive'
 import { getMappedKey } from '../../utils/data-mapping'
-import { ResponsiveState } from '../Responsive'
 import { Table, Spinner } from '../ui'
 import getColumns from './OrderHistory.columns'
 import { ORDER_HISTORY_COLUMNS, BREAKPOINT_SMALL } from './OrderHistory.constants'
@@ -22,13 +23,10 @@ export const OrderHistory = (props) => {
     loading,
     rowMapping,
     className,
-    isMobileLayout,
+    isMobileLayout: isMobile,
   } = props
   const { t } = useTranslation('orderhistory')
   const keyForId = getMappedKey(ORDER_HISTORY_COLUMNS.ID, rowMapping)
-  const { width } = ResponsiveState()
-  const isMobile = isMobileLayout !== undefined ? !!isMobileLayout : width < BREAKPOINT_SMALL
-
   const columns = useMemo(() => getColumns({ t, isMobile }), [t, isMobile])
 
   if (loading) {
@@ -99,4 +97,9 @@ export const defaultProps = {
 
 OrderHistory.defaultProps = defaultProps
 
-export default withI18nProvider(withResponsive(memo(OrderHistory)))
+export default compose(
+  withI18nProvider,
+  withResponsive,
+  withMobileLayout(BREAKPOINT_SMALL),
+  memo,
+)(OrderHistory)

--- a/src/components/Orders/Orders.js
+++ b/src/components/Orders/Orders.js
@@ -3,13 +3,14 @@ import _get from 'lodash/get'
 import PropTypes from 'prop-types'
 import React, { useMemo, memo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { compose } from 'react-redux'
 
 import * as Classes from '../../common/classes'
 import { DATA_MAPPING } from '../../common/props'
 import withI18nProvider from '../../hoc/withI18nProvider'
+import withMobileLayout from '../../hoc/withMobileLayout'
 import withResponsive from '../../hoc/withResponsive'
 import { getMappedKey } from '../../utils/data-mapping'
-import { ResponsiveState } from '../Responsive'
 import { Table, Spinner } from '../ui'
 import getColumns from './Orders.columns'
 import { KEYS, BREAKPOINT_SMALL } from './Orders.constants'
@@ -23,11 +24,9 @@ export const Orders = (props) => {
     rowMapping,
     className,
     cancelOrder,
-    parentWidth,
+    isMobileLayout: isMobile,
   } = props
   const { t } = useTranslation('orders')
-  const { width } = ResponsiveState()
-  const isMobile = (parentWidth || width) < BREAKPOINT_SMALL
   const keyForId = getMappedKey(KEYS.ID, rowMapping)
   const classes = cx(Classes.ORDERS, className, {
     'mobile-table': isMobile,
@@ -71,7 +70,11 @@ Orders.propTypes = {
   rowMapping: PropTypes.objectOf(PropTypes.shape(DATA_MAPPING)),
   className: PropTypes.string,
   cancelOrder: PropTypes.func.isRequired,
-  parentWidth: PropTypes.number,
+  /**
+   * If true, show the Orders in a condensed mobile layout. By default
+   * the mobile layout will be enabled when the screen size is below 576.
+   */
+  isMobileLayout: PropTypes.bool,
 }
 
 export const defaultProps = {
@@ -79,9 +82,14 @@ export const defaultProps = {
   loading: false,
   rowMapping: {},
   className: null,
-  parentWidth: null,
+  isMobileLayout: undefined,
 }
 
 Orders.defaultProps = defaultProps
 
-export default withI18nProvider(withResponsive(memo(Orders)))
+export default compose(
+  withI18nProvider,
+  withResponsive,
+  withMobileLayout(BREAKPOINT_SMALL),
+  memo,
+)(Orders)

--- a/src/hoc/withMobileLayout.js
+++ b/src/hoc/withMobileLayout.js
@@ -1,0 +1,31 @@
+import React, { forwardRef } from 'react'
+
+import { ResponsiveState } from '../components/Responsive'
+
+/**
+ * MobileLayoutWrapper
+ *
+ * HOC that passes the prop isMobileLayout to the child component
+ * Takes isMobileLayout if it’s passed as prop, or else checks if the
+ * components width is smaller than the breakpoint.
+ *
+ * Note: Requires to be wrapped inside a withResponsive HOC
+ *
+ * @param {Number} breakpoint
+ * @returns {ReactNode} Component
+ */
+// disabled arrow-callback rule to have display name in devtools instead of Anonymous
+// eslint-disable-next-line prefer-arrow-callback
+const MobileLayoutWrapper = (breakpoint = 576) => (Component) => forwardRef(function MobileLayoutWrapperComp(props, ref) {
+  const { width } = ResponsiveState()
+  const isMobileLayout = props.isMobileLayout !== undefined
+    ? !!props.isMobileLayout
+    : width < breakpoint
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Component ref={ref} {...props} isMobileLayout={isMobileLayout} />
+  )
+})
+
+export default MobileLayoutWrapper


### PR DESCRIPTION
## Prerequisites
N/A

(If the PR requires any other PRs to be applied first, indicate it here, otherwise put "N/A")


## Task reference




## PR description

Removes the parentWidth prop from the book component and uses the same mobileLayout logic as OrderHistory. Extracted the logic into a HOC which accepts a breakpoint arg.


## Example app screenshot
N/A

(Add example app screenshot if applicable, otherwise put "N/A")



## Storybook screenshot
N/A

(Add storybook screenshot if applicable, otherwise put "N/A")



## Checklist
  - [ ] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [ ] Added PR description
  - [ ] Relevant change in example app is verified, added example app screenshot
  - [ ] Storybook: stories, docs are updated/verified
  - [ ] Tests/snapshots are updated
  - [ ] Lint check passed
  - [ ] PR development is completed, the developer is satisfied with the code quality and behavior of the app
