### PR TITLE
(fix) Remove max-height from order history table

### DIFF
--- a/src/components/OrderHistory/_OrderHistory.scss
+++ b/src/components/OrderHistory/_OrderHistory.scss
@@ -1,4 +1,8 @@
 .#{$ns}-order-history {
+  .ufx-table-wrapper {
+    max-height: none;
+  }
+
   table {
     table-layout: fixed;
   }


### PR DESCRIPTION
## Prerequisites
N/A



## Task reference

https://app.asana.com/0/1125859137800433/1200260622693080

## BREAKING CHANGES
N/A


## PR description

There is a default max-height of 350px set on the table wrapper that causes this:

![image](https://user-images.githubusercontent.com/13964126/116579670-aad57f00-a923-11eb-8562-ce7980d406d1.png)



## Example app screenshot
N/A




## Storybook screenshot
N/A




## Checklist
  - [x] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [x] Relevant change in example app is verified, added example app screenshot
  - [x] Storybook: stories, docs are updated/verified
  - [x] Tests/snapshots are updated
  - [x] Lint check passed
  - [x] PR development is completed, the developer is satisfied with the code quality and behavior of the app
