### PR TITLE
(fix) rollup config

### DIFF
--- a/packages/bfx-containers/src/ufx-bfx-containers.scss
+++ b/packages/bfx-containers/src/ufx-bfx-containers.scss
@@ -1,4 +1,4 @@
-@import "../../core/dist/css/ufx-core.bundle.scss";
+@import "~@ufx-ui/core/dist/css/ufx-core.bundle.scss";
 
 @import "containers/index";
 

--- a/packages/bfx-containers/src/ufx-bfx-containers.scss
+++ b/packages/bfx-containers/src/ufx-bfx-containers.scss
@@ -1,4 +1,4 @@
-@import "~@ufx-ui/core/dist/css/ufx-core.bundle.scss";
+@import "../../core/dist/css/ufx-core.bundle.scss";
 
 @import "containers/index";
 

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -21,14 +21,12 @@ const { peerDependencies } = pkg
 const external = Object.keys(peerDependencies)
 external.push('@ufx-ui/utils')
 external.push('react-virtualized')
-external.push('react-outside-click-handler')
 
 const globals = {
   react: 'React',
   'react-dom': 'ReactDOM',
   '@ufx-ui/utils': 'UfxUIUtils',
   'react-virtualized': 'ReactVirtualized',
-  'react-outside-click-handler': 'ReactOutsideClickHandler',
 }
 
 const commonjsArgs = {

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -20,11 +20,13 @@ const input = pkg.source
 const { peerDependencies } = pkg
 const external = Object.keys(peerDependencies)
 external.push('@ufx-ui/utils')
+external.push('react-virtualized')
 
 const globals = {
   react: 'React',
   'react-dom': 'ReactDOM',
   '@ufx-ui/utils': 'UfxUIUtils',
+  'react-virtualized': 'ReactVirtualized',
 }
 
 const commonjsArgs = {

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -21,12 +21,14 @@ const { peerDependencies } = pkg
 const external = Object.keys(peerDependencies)
 external.push('@ufx-ui/utils')
 external.push('react-virtualized')
+external.push('react-outside-click-handler')
 
 const globals = {
   react: 'React',
   'react-dom': 'ReactDOM',
   '@ufx-ui/utils': 'UfxUIUtils',
   'react-virtualized': 'ReactVirtualized',
+  'react-outside-click-handler': 'ReactOutsideClickHandler',
 }
 
 const commonjsArgs = {


### PR DESCRIPTION
## Prerequisites
N/A

## Task reference
[Fix build warn reactVirtualized](https://app.asana.com/0/1189676765887416/1200321956674484/f)

## BREAKING CHANGES
N/A

## PR description
This PR fixes the rollup config for newly install external modules & CSS a issue related to VirtualTable.

## Example app screenshot
N/A

## Storybook screenshot
![Screenshot from 2021-05-13 12-41-57](https://user-images.githubusercontent.com/35810911/118108418-7e177200-b3cf-11eb-885e-a8e10d57b53e.png)

## Checklist
  - [x] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [x] Relevant change in example app is verified, added example app screenshot
  - [x] Storybook: stories, docs are updated/verified
  - [x] `Pull request verify workflow` passed
  - [x] PR development is completed, the developer is satisfied with the code quality and behavior of the app
