### PR TITLE
(improvement) Tooltip integration into Checkbox

### DIFF
--- a/packages/core/src/components/ui/Checkbox/Checkbox.js
+++ b/packages/core/src/components/ui/Checkbox/Checkbox.js
@@ -5,6 +5,7 @@ import React, { useRef, forwardRef } from 'react'
 import * as Classes from '../../../common/classes'
 import * as utils from '../../../common/utils'
 import Label from '../Label'
+import Tooltip from '../Tooltip'
 
 const stopPropagationOnClick = (e) => e.stopPropagation()
 
@@ -20,6 +21,7 @@ const Checkbox = forwardRef(function Checkbox(props, ref) {
     onChange,
     error,
     small,
+    customhelp,
     ...rest
   } = props
   const checkboxRef = useRef(null)
@@ -55,34 +57,36 @@ const Checkbox = forwardRef(function Checkbox(props, ref) {
   }
 
   return (
-    <div
-      ref={ref}
-      className={classes}
-      htmlFor={id}
-      tabIndex={disabled ? -1 : 0}
-      role='checkbox'
-      aria-checked={checked}
-      onClick={handleLabelClick}
-      onKeyPress={utils.handleKeyboardEvent(' ', handleLabelClick)}
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      {...rest}
-    >
-      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-      <input {...inputProps} />
+    <Tooltip content={customhelp}>
+      <div
+        ref={ref}
+        className={classes}
+        htmlFor={id}
+        tabIndex={disabled ? -1 : 0}
+        role='checkbox'
+        aria-checked={checked}
+        onClick={handleLabelClick}
+        onKeyPress={utils.handleKeyboardEvent(' ', handleLabelClick)}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...rest}
+      >
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+        <input {...inputProps} />
 
-      <Label
-        label={label || ''}
-        className={cx({ disabled })}
-        tag='div'
-        small={small}
-      />
+        <Label
+          label={label || ''}
+          className={cx({ disabled })}
+          tag='div'
+          small={small}
+        />
 
-      {error && (
-        <div className='error'>
-          {error}
-        </div>
-      )}
-    </div>
+        {error && (
+          <div className='error'>
+            {error}
+          </div>
+        )}
+      </div>
+    </Tooltip>
   )
 })
 
@@ -123,6 +127,10 @@ Checkbox.propTypes = {
    * If true, shows the Button in a small style.
    */
   small: PropTypes.bool,
+  /**
+   * A help message to be shown in the tooltip.
+   */
+  customhelp: PropTypes.string,
 }
 
 Checkbox.defaultProps = {
@@ -134,6 +142,7 @@ Checkbox.defaultProps = {
   onChange: () => { },
   error: '',
   small: false,
+  customhelp: '',
 }
 
 export default Checkbox

--- a/packages/core/src/components/ui/Checkbox/Checkbox.js
+++ b/packages/core/src/components/ui/Checkbox/Checkbox.js
@@ -57,7 +57,7 @@ const Checkbox = forwardRef(function Checkbox(props, ref) {
     ref: checkboxRef,
   }
 
-  const Component = () => (
+  const component = (
     <div
       ref={ref}
       className={classes}
@@ -88,17 +88,15 @@ const Checkbox = forwardRef(function Checkbox(props, ref) {
     </div>
   )
 
-  if (_isEmpty(helpMessage)) {
+  if (!_isEmpty(helpMessage)) {
     return (
-      <Component />
+      <Tooltip content={helpMessage}>
+        {component}
+      </Tooltip>
     )
   }
 
-  return (
-    <Tooltip content={helpMessage}>
-      <Component />
-    </Tooltip>
-  )
+  return component
 })
 
 Checkbox.propTypes = {

--- a/packages/core/src/components/ui/Checkbox/Checkbox.js
+++ b/packages/core/src/components/ui/Checkbox/Checkbox.js
@@ -1,4 +1,5 @@
 import cx from 'classnames'
+import _isEmpty from 'lodash/isEmpty'
 import PropTypes from 'prop-types'
 import React, { useRef, forwardRef } from 'react'
 
@@ -21,7 +22,7 @@ const Checkbox = forwardRef(function Checkbox(props, ref) {
     onChange,
     error,
     small,
-    customhelp,
+    helpMessage,
     ...rest
   } = props
   const checkboxRef = useRef(null)
@@ -56,36 +57,46 @@ const Checkbox = forwardRef(function Checkbox(props, ref) {
     ref: checkboxRef,
   }
 
+  const Component = () => (
+    <div
+      ref={ref}
+      className={classes}
+      htmlFor={id}
+      tabIndex={disabled ? -1 : 0}
+      role='checkbox'
+      aria-checked={checked}
+      onClick={handleLabelClick}
+      onKeyPress={utils.handleKeyboardEvent(' ', handleLabelClick)}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...rest}
+    >
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <input {...inputProps} />
+
+      <Label
+        label={label || ''}
+        className={cx({ disabled })}
+        tag='div'
+        small={small}
+      />
+
+      {error && (
+        <div className='error'>
+          {error}
+        </div>
+      )}
+    </div>
+  )
+
+  if (_isEmpty(helpMessage)) {
+    return (
+      <Component />
+    )
+  }
+
   return (
-    <Tooltip content={customhelp}>
-      <div
-        ref={ref}
-        className={classes}
-        htmlFor={id}
-        tabIndex={disabled ? -1 : 0}
-        role='checkbox'
-        aria-checked={checked}
-        onClick={handleLabelClick}
-        onKeyPress={utils.handleKeyboardEvent(' ', handleLabelClick)}
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...rest}
-      >
-        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-        <input {...inputProps} />
-
-        <Label
-          label={label || ''}
-          className={cx({ disabled })}
-          tag='div'
-          small={small}
-        />
-
-        {error && (
-          <div className='error'>
-            {error}
-          </div>
-        )}
-      </div>
+    <Tooltip content={helpMessage}>
+      <Component />
     </Tooltip>
   )
 })
@@ -130,7 +141,7 @@ Checkbox.propTypes = {
   /**
    * A help message to be shown in the tooltip.
    */
-  customhelp: PropTypes.string,
+  helpMessage: PropTypes.string,
 }
 
 Checkbox.defaultProps = {
@@ -142,7 +153,7 @@ Checkbox.defaultProps = {
   onChange: () => { },
   error: '',
   small: false,
-  customhelp: '',
+  helpMessage: '',
 }
 
 export default Checkbox

--- a/packages/core/src/components/ui/Checkbox/stories/Checkbox.stories.js
+++ b/packages/core/src/components/ui/Checkbox/stories/Checkbox.stories.js
@@ -9,7 +9,7 @@ export default getDefaultMetadata(Checkbox, 'Components/ui/Checkbox', {}, true)
 const props = {
   label: 'Auto Save',
   checked: false,
-  customhelp: 'This is a custom help message!',
+  helpMessage: 'This is a custom help message!',
 }
 
 export const basic = showTemplateStory(Checkbox, props)

--- a/packages/core/src/components/ui/Checkbox/stories/Checkbox.stories.js
+++ b/packages/core/src/components/ui/Checkbox/stories/Checkbox.stories.js
@@ -9,6 +9,7 @@ export default getDefaultMetadata(Checkbox, 'Components/ui/Checkbox', {}, true)
 const props = {
   label: 'Auto Save',
   checked: false,
+  customhelp: 'This is a custom help message!',
 }
 
 export const basic = showTemplateStory(Checkbox, props)

--- a/packages/core/src/components/ui/Tooltip/Tooltip.js
+++ b/packages/core/src/components/ui/Tooltip/Tooltip.js
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { forwardRef } from 'react'
 import TooltipTrigger from 'react-popper-tooltip'
+import _isEmpty from 'lodash/isEmpty'
 
 import * as Classes from '../../../common/classes'
 
@@ -61,6 +62,12 @@ const Tooltip = forwardRef(function Tooltip(props, ref) {
   const tooltipClasses = cx(className, {
     [`${Classes.TOOLTIP}--persistent`]: persistent,
   })
+
+  if (_isEmpty(content)) {
+    return (
+      <>{children}</>
+    )
+  }
 
   return (
     <TooltipTrigger

--- a/packages/core/src/components/ui/Tooltip/Tooltip.js
+++ b/packages/core/src/components/ui/Tooltip/Tooltip.js
@@ -1,9 +1,9 @@
 /* eslint-disable react/jsx-indent */
 import cx from 'classnames'
+import _isEmpty from 'lodash/isEmpty'
 import PropTypes from 'prop-types'
 import React, { forwardRef } from 'react'
 import TooltipTrigger from 'react-popper-tooltip'
-import _isEmpty from 'lodash/isEmpty'
 
 import * as Classes from '../../../common/classes'
 

--- a/packages/core/src/components/ui/Tooltip/Tooltip.js
+++ b/packages/core/src/components/ui/Tooltip/Tooltip.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-indent */
 import cx from 'classnames'
-import _isEmpty from 'lodash/isEmpty'
 import PropTypes from 'prop-types'
 import React, { forwardRef } from 'react'
 import TooltipTrigger from 'react-popper-tooltip'
@@ -62,12 +61,6 @@ const Tooltip = forwardRef(function Tooltip(props, ref) {
   const tooltipClasses = cx(className, {
     [`${Classes.TOOLTIP}--persistent`]: persistent,
   })
-
-  if (_isEmpty(content)) {
-    return (
-      <>{children}</>
-    )
-  }
 
   return (
     <TooltipTrigger


### PR DESCRIPTION
## Prerequisites
N/A

## Task reference
[Integrate Tooltip into Checkbox](https://app.asana.com/0/1125859137800433/1200364909009321/f)

## BREAKING CHANGES
Updated Checkbox component is fully backward compatible with previous versions.

## PR description
This RP adds a Tooltip into Checkbox component if `customhelp` prop is provided. This feature is already being used in the HFUI Checkbox component and should be added here as well ([Checkbox integration PR](https://github.com/bitfinexcom/bfx-hf-ui/blob/004189b87322e9f7cd78d0bc07e7a9ff711fd354/src/components/OrderForm/FieldComponents/input.checkbox.js) already uses `customhelp` prop).

## Example app screenshot
N/A

## Storybook screenshot
![Screenshot from 2021-05-21 14-11-01](https://user-images.githubusercontent.com/35810911/119129693-c44f7f80-ba26-11eb-872f-5063ac01bde6.png)

## Checklist
  - [x] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [x] Relevant change in example app is verified, added example app screenshot
  - [x] Storybook: stories, docs are updated/verified
  - [x] `Pull request verify workflow` passed
  - [x] PR development is completed, the developer is satisfied with the code quality and behavior of the app
