### PR TITLE
(fix) Add !default flag to Dialog scss vars

### DIFF
--- a/packages/core/src/components/ui/Dialog/Dialog.Modal.js
+++ b/packages/core/src/components/ui/Dialog/Dialog.Modal.js
@@ -40,7 +40,7 @@ const Modal = forwardRef(({
       >
         {isCloseButtonShown && (
           <button type='button' className='modal__close-button' onClick={onClose}>
-            &times;
+            &#10005;
           </button>
         )}
         {Icon && (

--- a/packages/core/src/components/ui/Dialog/_Dialog.scss
+++ b/packages/core/src/components/ui/Dialog/_Dialog.scss
@@ -112,7 +112,7 @@ $mobile-media: "(max-width: 768px)";
       top: 4px;
       right: 4px;
       display: block;
-      font-size: $ufx-dialog-header-height;
+      font-size: 18px;
       font-weight: 300;
       width: $ufx-dialog-header-height;
       line-height: $ufx-dialog-header-height;

--- a/packages/core/src/components/ui/Dialog/_Dialog.scss
+++ b/packages/core/src/components/ui/Dialog/_Dialog.scss
@@ -1,7 +1,7 @@
-$ufx-dialog-header-height: $ufx-base-size * 3.2;
-$ufx-dialog-padding-desktop: $ufx-base-size * 2;
-$ufx-dialog-padding-mobile: $ufx-base-size * 1.6;
-$ufx-dialog-title: $ufx-base-size * 1.8;
+$ufx-dialog-header-height: $ufx-base-size * 3.2 !default;
+$ufx-dialog-padding-desktop: $ufx-base-size * 2 !default;
+$ufx-dialog-padding-mobile: $ufx-base-size * 1.6 !default;
+$ufx-dialog-title: $ufx-base-size * 1.8 !default;
 
 $mobile-media: "(max-width: 768px)";
 


### PR DESCRIPTION
## Prerequisites
N/A



## Task reference


## BREAKING CHANGES
N/A



## PR description

Currently these vars can't be overridden by an app because of the missing !default flags.


## Example app screenshot
N/A



## Storybook screenshot
N/A




## Checklist
  - [x] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [x] Relevant change in example app is verified, added example app screenshot
  - [x] Storybook: stories, docs are updated/verified
  - [x] `Pull request verify workflow` passed
  - [x] PR development is completed, the developer is satisfied with the code quality and behavior of the app
