### PR TITLE
(fix) TickerList: prevent showing favorites tickers list if one is empty

### DIFF
--- a/packages/core/src/components/TickerList/TickerList.js
+++ b/packages/core/src/components/TickerList/TickerList.js
@@ -44,19 +44,6 @@ export const TickerList = (props) => {
   const [searchTerm, setSearchTerm] = useState('')
   const { t } = useTranslation()
 
-  const showOnlyFavsMemo = useMemo(() => {
-    if (!showOnlyFavs) {
-      // avoid to create an array L52
-      return false
-    }
-    const favValuesArray = Object.values(favs)
-    if (favValuesArray.length === 0 || !favValuesArray.includes(true)) {
-      // if fav object is empty or there are only false values
-      return false
-    }
-    return true
-  }, [showOnlyFavs, favs])
-
   const ordered = _orderBy(
     data,
     [sortBy],
@@ -76,7 +63,7 @@ export const TickerList = (props) => {
 
       return (
         _includes(matches, _toLower(searchTerm))
-        && (!showOnlyFavsMemo || favs[row[keyForId]])
+        && (!showOnlyFavs || favs[row[keyForId]])
       )
     },
   )
@@ -97,6 +84,22 @@ export const TickerList = (props) => {
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
       />
+      <Table condensed>
+        <TickerListHeader
+          sortBy={sortBy}
+          setSortBy={setSortBy}
+          sortAsc={sortAsc}
+          setSortAsc={setSortAsc}
+          showOnlyFavs={showOnlyFavs}
+          setShowOnlyFavs={setShowOnlyFavs}
+          showVolumeUnit={showVolumeUnit}
+          volumeUnitList={volumeUnitList}
+          volumeUnit={volumeUnit}
+          setVolumeUnit={setVolumeUnit}
+          dataMapping={rowMapping}
+          columns={columns}
+        />
+      </Table>
       {_isEmpty(filtered)
         ? (
           <div className='empty-tickerlist'>
@@ -104,44 +107,26 @@ export const TickerList = (props) => {
           </div>
         )
         : (
-          <>
-            <Table condensed>
-              <TickerListHeader
-                sortBy={sortBy}
-                setSortBy={setSortBy}
-                sortAsc={sortAsc}
-                setSortAsc={setSortAsc}
-                showOnlyFavs={showOnlyFavsMemo}
-                setShowOnlyFavs={setShowOnlyFavs}
-                showVolumeUnit={showVolumeUnit}
-                volumeUnitList={volumeUnitList}
-                volumeUnit={volumeUnit}
-                setVolumeUnit={setVolumeUnit}
-                dataMapping={rowMapping}
-                columns={columns}
-              />
+          <div className={Classes.TABLE_WRAPPER}>
+            <Table condensed interactive striped>
+              <tbody>
+                {filtered.map((row) => {
+                  const id = _get(row, keyForId)
+                  return (
+                    <Row
+                      key={id}
+                      data={row}
+                      dataMapping={rowMapping}
+                      isFav={!!favs[id]}
+                      toggleFav={toggleFav}
+                      onRowClick={onRowClick}
+                      columns={columns}
+                    />
+                  )
+                })}
+              </tbody>
             </Table>
-            <div className={Classes.TABLE_WRAPPER}>
-              <Table condensed interactive striped>
-                <tbody>
-                  {filtered.map((row) => {
-                    const id = _get(row, keyForId)
-                    return (
-                      <Row
-                        key={id}
-                        data={row}
-                        dataMapping={rowMapping}
-                        isFav={!!favs[id]}
-                        toggleFav={toggleFav}
-                        onRowClick={onRowClick}
-                        columns={columns}
-                      />
-                    )
-                  })}
-                </tbody>
-              </Table>
-            </div>
-          </>
+          </div>
         )}
     </div>
   )

--- a/packages/core/src/components/TickerList/TickerList.js
+++ b/packages/core/src/components/TickerList/TickerList.js
@@ -44,6 +44,19 @@ export const TickerList = (props) => {
   const [searchTerm, setSearchTerm] = useState('')
   const { t } = useTranslation()
 
+  const showOnlyFavsMemo = useMemo(() => {
+    if (!showOnlyFavs) {
+      // avoid to create an array L52
+      return false
+    }
+    const favValuesArray = Object.values(favs)
+    if (favValuesArray.length === 0 || !favValuesArray.includes(true)) {
+      // if fav object is empty or there are only false values
+      return false
+    }
+    return true
+  }, [showOnlyFavs, favs])
+
   const ordered = _orderBy(
     data,
     [sortBy],
@@ -63,7 +76,7 @@ export const TickerList = (props) => {
 
       return (
         _includes(matches, _toLower(searchTerm))
-        && (!showOnlyFavs || favs[row[keyForId]])
+        && (!showOnlyFavsMemo || favs[row[keyForId]])
       )
     },
   )
@@ -98,7 +111,7 @@ export const TickerList = (props) => {
                 setSortBy={setSortBy}
                 sortAsc={sortAsc}
                 setSortAsc={setSortAsc}
-                showOnlyFavs={showOnlyFavs}
+                showOnlyFavs={showOnlyFavsMemo}
                 setShowOnlyFavs={setShowOnlyFavs}
                 showVolumeUnit={showVolumeUnit}
                 volumeUnitList={volumeUnitList}


### PR DESCRIPTION
## Prerequisites
N/A


## Task reference
https://app.asana.com/0/1125859137800433/1200421515632005

## BREAKING CHANGES
N/A


## PR description
Prevent showing favorites list if list is empty or all values are falsy


## Example app screenshot
![Снимок экрана от 2021-06-03 21-04-37](https://user-images.githubusercontent.com/81973123/120694619-1e365780-c4b3-11eb-8ec1-0bafca6b3eb2.png)
![Снимок экрана от 2021-06-03 21-04-59](https://user-images.githubusercontent.com/81973123/120694690-2d1d0a00-c4b3-11eb-9d0a-294bc197fa16.png)


## Storybook screenshot
N/A


## Checklist
  - [x] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [x] Relevant change in example app is verified, added example app screenshot
  - [x] Storybook: stories, docs are updated/verified
  - [x] `Pull request verify workflow` passed
  - [x] PR development is completed, the developer is satisfied with the code quality and behavior of the app
