### PR TITLE
(fix): TickerList: removed margins from FontAwesome styles in Searchbar

### DIFF
--- a/packages/core/src/components/TickerList/_TickerList.scss
+++ b/packages/core/src/components/TickerList/_TickerList.scss
@@ -76,6 +76,7 @@
 
   .search-icon {
     align-self: center;
+    margin: 0;
     margin-right: $ufx-base-size * 0.5;
   }
 


### PR DESCRIPTION
## Prerequisites
N/A


## Task reference
https://app.asana.com/0/1189676765887416/1200440982123206

## BREAKING CHANGES
N/A

(Explain here, any breaking changes that do not have backward compatibility with previous versions of ufx-ui or keep N/A
i.e. if you renamed some component prop. Someone who is using previous version, should work on these updates, before upating their `ufx-ui` dependency to this version)


## PR description
faTimes icon gives additional margins, that makes input's height bigger. Rewrite margins to 0 before declairing margin-right property



## Example app screenshot
![Снимок экрана от 2021-06-08 16-20-01](https://user-images.githubusercontent.com/81973123/121192251-6cfa3d80-c875-11eb-9ab0-06bd8458c660.png)
![Снимок экрана от 2021-06-08 16-20-07](https://user-images.githubusercontent.com/81973123/121192256-6e2b6a80-c875-11eb-97c6-d78904055b86.png)




## Storybook screenshot
N/A



## Checklist
  - [x] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [x] Relevant change in example app is verified, added example app screenshot
  - [x] Storybook: stories, docs are updated/verified
  - [x] `Pull request verify workflow` passed
  - [x] PR development is completed, the developer is satisfied with the code quality and behavior of the app
