### PR TITLE
(feature) Ticker/TickerList: showing perp ccy in correct format

### DIFF
--- a/packages/core/src/components/Ticker/Ticker.constants.js
+++ b/packages/core/src/components/Ticker/Ticker.constants.js
@@ -15,15 +15,16 @@ export const KEYS = {
   VOLUME: 'volume',
   HIGH: 'high',
   LOW: 'low',
-  PERP_UI: 'perpUI',
 }
 
 export const MAPPING = {
-  [KEYS.QUOTE_CCY]: {
-    renderer: ({ formattedValue }) => `/ ${formattedValue}`,
-  },
-  [KEYS.PERP_UI]: {
-    renderer: ({ formattedValue }) => formattedValue,
+  [KEYS.BASE_CCY]: {
+    renderer: ({ baseCcy, quoteCcy }) => (
+      <>
+        <div className='highlight'>{baseCcy}</div>
+        /<div className='quote-ccy'>{quoteCcy}</div>
+      </>
+    ),
   },
   [KEYS.LAST_PRICE]: {
     defaultValue: 0,

--- a/packages/core/src/components/Ticker/Ticker.constants.js
+++ b/packages/core/src/components/Ticker/Ticker.constants.js
@@ -15,11 +15,15 @@ export const KEYS = {
   VOLUME: 'volume',
   HIGH: 'high',
   LOW: 'low',
+  PERP_UI: 'perpUI',
 }
 
 export const MAPPING = {
   [KEYS.QUOTE_CCY]: {
     renderer: ({ formattedValue }) => `/ ${formattedValue}`,
+  },
+  [KEYS.PERP_UI]: {
+    renderer: ({ formattedValue }) => formattedValue,
   },
   [KEYS.LAST_PRICE]: {
     defaultValue: 0,

--- a/packages/core/src/components/Ticker/Ticker.js
+++ b/packages/core/src/components/Ticker/Ticker.js
@@ -54,8 +54,12 @@ export const Ticker = (props) => {
     <div className={classes}>
       <div className='info'>
         {ccyIcon && <div className='ccy-icon'>{ccyIcon}</div>}
-        <div className='highlight'>{renderCell(KEYS.BASE_CCY)}</div>
-        <div className='quote-ccy'>{renderCell(KEYS.QUOTE_CCY)}</div>
+        {data.isPerp ? <div className='quote-ccy'>{renderCell(KEYS.PERP_UI)}</div> : (
+          <>
+            <div className='highlight'>{renderCell(KEYS.BASE_CCY)}</div>
+            <div className='quote-ccy'>{renderCell(KEYS.QUOTE_CCY)}</div>
+          </>
+        )}
         {showCoinInfoIcon && (
           <Button
             className='info-icon'

--- a/packages/core/src/components/Ticker/Ticker.js
+++ b/packages/core/src/components/Ticker/Ticker.js
@@ -29,6 +29,7 @@ export const Ticker = (props) => {
     data,
   })
 
+  const baseCcy = getDisplayValue(KEYS.BASE_CCY)
   const quoteCcy = getDisplayValue(KEYS.QUOTE_CCY)
   const changePerc = getDisplayValue(KEYS.CHANGE_PERC, false)
 
@@ -45,6 +46,7 @@ export const Ticker = (props) => {
       value,
       formattedValue,
       data,
+      baseCcy,
       quoteCcy,
       volumeUnit,
     })
@@ -54,12 +56,7 @@ export const Ticker = (props) => {
     <div className={classes}>
       <div className='info'>
         {ccyIcon && <div className='ccy-icon'>{ccyIcon}</div>}
-        {data.isPerp ? <div className='quote-ccy'>{renderCell(KEYS.PERP_UI)}</div> : (
-          <>
-            <div className='highlight'>{renderCell(KEYS.BASE_CCY)}</div>
-            <div className='quote-ccy'>{renderCell(KEYS.QUOTE_CCY)}</div>
-          </>
-        )}
+        {renderCell(KEYS.BASE_CCY)}
         {showCoinInfoIcon && (
           <Button
             className='info-icon'

--- a/packages/core/src/components/TickerList/TickerList.Row.js
+++ b/packages/core/src/components/TickerList/TickerList.Row.js
@@ -29,8 +29,6 @@ const TickerListRow = (props) => {
 
   const baseCcy = getDisplayValue(KEYS.BASE_CCY)
   const quoteCcy = getDisplayValue(KEYS.QUOTE_CCY)
-  const perpUI = getDisplayValue(KEYS.PERP_UI)
-  const isPerp = getDisplayValue(KEYS.IS_PERP)
   const id = getDisplayValue(KEYS.ID)
 
   const handleRowClick = () => {
@@ -72,8 +70,6 @@ const TickerListRow = (props) => {
               data,
               baseCcy,
               quoteCcy,
-              perpUI,
-              isPerp,
             }) : formattedValue}
           </td>
         )

--- a/packages/core/src/components/TickerList/TickerList.Row.js
+++ b/packages/core/src/components/TickerList/TickerList.Row.js
@@ -29,6 +29,8 @@ const TickerListRow = (props) => {
 
   const baseCcy = getDisplayValue(KEYS.BASE_CCY)
   const quoteCcy = getDisplayValue(KEYS.QUOTE_CCY)
+  const perpUI = getDisplayValue(KEYS.PERP_UI)
+  const isPerp = getDisplayValue(KEYS.IS_PERP)
   const id = getDisplayValue(KEYS.ID)
 
   const handleRowClick = () => {
@@ -70,6 +72,8 @@ const TickerListRow = (props) => {
               data,
               baseCcy,
               quoteCcy,
+              perpUI,
+              isPerp,
             }) : formattedValue}
           </td>
         )

--- a/packages/core/src/components/TickerList/TickerList.columns.js
+++ b/packages/core/src/components/TickerList/TickerList.columns.js
@@ -15,12 +15,19 @@ const getColumns = ({ t } = {}) => [{
   defaultSortAsc: true,
   cellStyle: { width: '26%', textAlign: 'left', wordBreak: 'break-all' },
   headerCellClassName: 'pair',
-  renderer: ({ baseCcy, quoteCcy }) => (
-    <span>
-      {baseCcy}
-      /
-      <span className='price-unit'>{quoteCcy}</span>
-    </span>
+  renderer: ({
+    baseCcy, quoteCcy, perpUI, isPerp,
+  }) => (
+    <>
+      {isPerp ? <span>{perpUI}</span> : (
+        <span>
+          {baseCcy}
+          /
+          <span className='price-unit'>{quoteCcy}</span>
+        </span>
+      )}
+    </>
+
   ),
 }, {
   label: t('tickerlist:last_price'),

--- a/packages/core/src/components/TickerList/TickerList.columns.js
+++ b/packages/core/src/components/TickerList/TickerList.columns.js
@@ -16,16 +16,14 @@ const getColumns = ({ t } = {}) => [{
   cellStyle: { width: '26%', textAlign: 'left', wordBreak: 'break-all' },
   headerCellClassName: 'pair',
   renderer: ({
-    baseCcy, quoteCcy, perpUI, isPerp,
+    baseCcy, quoteCcy,
   }) => (
     <>
-      {isPerp ? <span>{perpUI}</span> : (
-        <span>
-          {baseCcy}
-          /
-          <span className='price-unit'>{quoteCcy}</span>
-        </span>
-      )}
+      <span>
+        {baseCcy}
+        /
+        <span className='price-unit'>{quoteCcy}</span>
+      </span>
     </>
 
   ),

--- a/packages/core/src/components/TickerList/TickerList.constants.js
+++ b/packages/core/src/components/TickerList/TickerList.constants.js
@@ -9,6 +9,8 @@ export const KEYS = {
   CHANGE_PERC: 'changePerc',
   CCY_LABELS: 'ccyLabels',
   VOLUME: 'volume',
+  PERP_UI: 'perpUI',
+  IS_PERP: 'isPerp',
 }
 
 const formatVolumePerc = (value) => `${(value * 100).toFixed(2)}%`

--- a/packages/core/src/components/TickerList/TickerList.constants.js
+++ b/packages/core/src/components/TickerList/TickerList.constants.js
@@ -9,8 +9,6 @@ export const KEYS = {
   CHANGE_PERC: 'changePerc',
   CCY_LABELS: 'ccyLabels',
   VOLUME: 'volume',
-  PERP_UI: 'perpUI',
-  IS_PERP: 'isPerp',
 }
 
 const formatVolumePerc = (value) => `${(value * 100).toFixed(2)}%`

--- a/packages/core/src/components/TickerList/TickerList.js
+++ b/packages/core/src/components/TickerList/TickerList.js
@@ -40,7 +40,6 @@ export const TickerList = (props) => {
   const keyForQuoteCcy = getMappedKey(KEYS.QUOTE_CCY, rowMapping)
   const keyForCcyLabels = getMappedKey(KEYS.CCY_LABELS, rowMapping)
   const keyForVolume = getMappedKey(KEYS.VOLUME, rowMapping)
-  const keyForPerpUI = getMappedKey(KEYS.PERP_UI, rowMapping)
   const [sortBy, setSortBy] = useState(keyForVolume)
   const [sortAsc, setSortAsc] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
@@ -57,13 +56,10 @@ export const TickerList = (props) => {
     (row) => {
       const baseCcy = _get(row, keyForBaseCcy)
       const quoteCcy = _get(row, keyForQuoteCcy)
-      const perpUI = _get(row, keyForPerpUI)
-      const ccyLabels = _get(row, keyForCcyLabels, [baseCcy, quoteCcy])
+      const defaultLabels = [baseCcy, quoteCcy, baseCcy + quoteCcy, `${baseCcy}/${quoteCcy}`]
+      const ccyLabels = _get(row, keyForCcyLabels, [])
 
-      const matches = _toLower(_join([
-        ...ccyLabels,
-        baseCcy + quoteCcy, perpUI && perpUI,
-      ]))
+      const matches = _toLower(_join([...ccyLabels, ...defaultLabels]))
 
       return (
         _includes(matches, _toLower(searchTerm))

--- a/packages/core/src/components/TickerList/TickerList.js
+++ b/packages/core/src/components/TickerList/TickerList.js
@@ -40,6 +40,7 @@ export const TickerList = (props) => {
   const keyForQuoteCcy = getMappedKey(KEYS.QUOTE_CCY, rowMapping)
   const keyForCcyLabels = getMappedKey(KEYS.CCY_LABELS, rowMapping)
   const keyForVolume = getMappedKey(KEYS.VOLUME, rowMapping)
+  const keyForPerpUI = getMappedKey(KEYS.PERP_UI, rowMapping)
   const [sortBy, setSortBy] = useState(keyForVolume)
   const [sortAsc, setSortAsc] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
@@ -56,12 +57,12 @@ export const TickerList = (props) => {
     (row) => {
       const baseCcy = _get(row, keyForBaseCcy)
       const quoteCcy = _get(row, keyForQuoteCcy)
-      // added backward compatibility
+      const perpUI = _get(row, keyForPerpUI)
       const ccyLabels = _get(row, keyForCcyLabels, [baseCcy, quoteCcy])
 
       const matches = _toLower(_join([
         ...ccyLabels,
-        baseCcy + quoteCcy,
+        baseCcy + quoteCcy, perpUI && perpUI,
       ]))
 
       return (

--- a/packages/core/src/components/TickerList/stories/TickerList.stories_data.js
+++ b/packages/core/src/components/TickerList/stories/TickerList.stories_data.js
@@ -7,6 +7,8 @@ const tickerList = [
     lastPrice: 4.019,
     volume: 402,
     ccyLabels: ['UST', 'Tether USDt', 'EOS'],
+    isPerp: false,
+    perpUI: null,
   }, {
     id: 'tBTCUSD',
     baseCcy: 'BTC',
@@ -15,6 +17,8 @@ const tickerList = [
     lastPrice: 9000,
     volume: 3940,
     ccyLabels: ['BTC', 'Bitcoin', 'USD', 'US Dollar'],
+    isPerp: false,
+    perpUI: null,
   }, {
     id: 'tBTCUST',
     baseCcy: 'BTC',
@@ -23,6 +27,19 @@ const tickerList = [
     lastPrice: 200,
     volume: 10000,
     ccyLabels: ['BTC', 'Bitcoin', 'UST', 'Tether USDt'],
+    isPerp: false,
+    perpUI: null,
+  },
+  {
+    id: 'tXLMF0:USTF0',
+    baseCcy: 'tXLMF0',
+    quoteCcy: 'USTF0',
+    changePerc: 2,
+    lastPrice: 20,
+    volume: 5587,
+    ccyLabels: ['tXLMF0', 'USTF0'],
+    isPerp: true,
+    perpUI: 'XLM-PERP',
   },
 ]
 

--- a/packages/core/src/components/TickerList/stories/TickerList.stories_data.js
+++ b/packages/core/src/components/TickerList/stories/TickerList.stories_data.js
@@ -7,8 +7,6 @@ const tickerList = [
     lastPrice: 4.019,
     volume: 402,
     ccyLabels: ['UST', 'Tether USDt', 'EOS'],
-    isPerp: false,
-    perpUI: null,
   }, {
     id: 'tBTCUSD',
     baseCcy: 'BTC',
@@ -17,8 +15,6 @@ const tickerList = [
     lastPrice: 9000,
     volume: 3940,
     ccyLabels: ['BTC', 'Bitcoin', 'USD', 'US Dollar'],
-    isPerp: false,
-    perpUI: null,
   }, {
     id: 'tBTCUST',
     baseCcy: 'BTC',
@@ -27,8 +23,6 @@ const tickerList = [
     lastPrice: 200,
     volume: 10000,
     ccyLabels: ['BTC', 'Bitcoin', 'UST', 'Tether USDt'],
-    isPerp: false,
-    perpUI: null,
   },
   {
     id: 'tXLMF0:USTF0',
@@ -38,8 +32,6 @@ const tickerList = [
     lastPrice: 20,
     volume: 5587,
     ccyLabels: ['tXLMF0', 'USTF0'],
-    isPerp: true,
-    perpUI: 'XLM-PERP',
   },
 ]
 


### PR DESCRIPTION
## Prerequisites
https://github.com/bitfinexcom/bfx-hf-ui/pull/481

(If the PR requires any other PRs to be applied first, indicate it here, otherwise put "N/A")


## Task reference
https://app.asana.com/0/1125859137800433/1200434110231990

## BREAKING CHANGES
Added properties of data prop object: isPerp (bool) and perpUI (string) in Ticker and TickerList

(Explain here, any breaking changes that do not have backward compatibility with previous versions of ufx-ui or keep N/A
i.e. if you renamed some component prop. Someone who is using previous version, should work on these updates, before upating their `ufx-ui` dependency to this version)


## PR description
Showing perp ccy in correct format



## Example app screenshot
![Снимок экрана от 2021-06-10 17-53-30](https://user-images.githubusercontent.com/81973123/121558176-19772380-ca1e-11eb-8773-6be1ec96d9d6.png)






## Storybook screenshot

![Снимок экрана от 2021-06-10 18-14-33](https://user-images.githubusercontent.com/81973123/121558078-01070900-ca1e-11eb-987e-785d46a86b19.png)




## Checklist
  - [x] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [x] Relevant change in example app is verified, added example app screenshot
  - [x] Storybook: stories, docs are updated/verified
  - [x] `Pull request verify workflow` passed
  - [x] PR development is completed, the developer is satisfied with the code quality and behavior of the app
