### PR TITLE
(improvement) Add font feature settings tnum

### DIFF
--- a/packages/core/src/components/Balances/_Balances.scss
+++ b/packages/core/src/components/Balances/_Balances.scss
@@ -23,6 +23,8 @@
   }
 
   tbody {
+    font-feature-settings: "tnum";
+
     td.#{$ns}-rtl {
       padding-right: $ufx-base-size;
     }

--- a/packages/core/src/components/Book/_Book.scss
+++ b/packages/core/src/components/Book/_Book.scss
@@ -22,6 +22,7 @@ $ufx-book-side-min-width: $ufx-base-size * 27;
   .rows {
     display: flex;
     flex-direction: column;
+    font-feature-settings: "tnum";
   }
 
   .row {

--- a/packages/core/src/components/OrderHistory/OrderHistory.columns.js
+++ b/packages/core/src/components/OrderHistory/OrderHistory.columns.js
@@ -73,7 +73,7 @@ const getColumns = (args = {}) => {
       label: t('amount'),
       cellStyle: { width: '15%' },
       headerCellClassName: Classes.RIGHT_TO_LEFT,
-      cellClassName: Classes.RIGHT_TO_LEFT,
+      cellClassName: cx(Classes.RIGHT_TO_LEFT, 'is-monospaced'),
       truncate: true,
     },
     {
@@ -89,7 +89,7 @@ const getColumns = (args = {}) => {
       label: t('price'),
       cellStyle: { width: isMobile ? '20%' : '12.5%' },
       headerCellClassName: Classes.RIGHT_TO_LEFT,
-      cellClassName: Classes.RIGHT_TO_LEFT,
+      cellClassName: cx(Classes.RIGHT_TO_LEFT, 'is-monospaced'),
       truncate: true,
     },
     {
@@ -97,7 +97,7 @@ const getColumns = (args = {}) => {
       label: t('average_price'),
       cellStyle: { width: isMobile ? '18%' : '12.5%' },
       headerCellClassName: Classes.RIGHT_TO_LEFT,
-      cellClassName: Classes.RIGHT_TO_LEFT,
+      cellClassName: cx(Classes.RIGHT_TO_LEFT, 'is-monospaced'),
       truncate: true,
     },
     {

--- a/packages/core/src/components/OrderHistory/_OrderHistory.scss
+++ b/packages/core/src/components/OrderHistory/_OrderHistory.scss
@@ -11,6 +11,10 @@
     word-wrap: break-word;
   }
 
+  .is-monospaced {
+    font-feature-settings: "tnum";
+  }
+
   .empty {
     text-align: center;
     padding: 1em 0.5em;

--- a/packages/core/src/components/Orders/Orders.columns.js
+++ b/packages/core/src/components/Orders/Orders.columns.js
@@ -71,7 +71,7 @@ const getColumns = (args = {}) => {
       label: t('amount'),
       cellStyle: { width: '15%' },
       headerCellClassName: Classes.RIGHT_TO_LEFT,
-      cellClassName: Classes.RIGHT_TO_LEFT,
+      cellClassName: cx(Classes.RIGHT_TO_LEFT, 'is-monospaced'),
       truncate: true,
     },
     {
@@ -87,7 +87,7 @@ const getColumns = (args = {}) => {
       label: t('price'),
       cellStyle: { width: isMobile ? '20%' : '17%' },
       headerCellClassName: Classes.RIGHT_TO_LEFT,
-      cellClassName: Classes.RIGHT_TO_LEFT,
+      cellClassName: cx(Classes.RIGHT_TO_LEFT, 'is-monospaced'),
       truncate: true,
     },
     {

--- a/packages/core/src/components/Orders/_Orders.scss
+++ b/packages/core/src/components/Orders/_Orders.scss
@@ -7,6 +7,10 @@
     word-wrap: break-word;
   }
 
+  .is-monospaced {
+    font-feature-settings: "tnum";
+  }
+
   .empty {
     text-align: center;
     padding: 1em 0.5em;

--- a/packages/core/src/components/TickerList/_TickerList.scss
+++ b/packages/core/src/components/TickerList/_TickerList.scss
@@ -25,6 +25,7 @@
   .#{$ns}-table tbody {
     td {
       vertical-align: middle;
+      font-feature-settings: "tnum";
     }
 
     td:not(:nth-child(1)) {

--- a/packages/core/src/components/TickerList/_TickerList.scss
+++ b/packages/core/src/components/TickerList/_TickerList.scss
@@ -25,7 +25,6 @@
   .#{$ns}-table tbody {
     td {
       vertical-align: middle;
-      font-feature-settings: "tnum";
     }
 
     td:not(:nth-child(1)) {

--- a/packages/core/src/components/Trades/_Trades.scss
+++ b/packages/core/src/components/Trades/_Trades.scss
@@ -1,6 +1,10 @@
 .#{$ns}-trades {
   line-height: $ufx-base-size * 1.4;
 
+  tbody {
+    font-feature-settings: "tnum";
+  }
+
   &__error {
     text-align: center;
     padding: 1em 0.5em;


### PR DESCRIPTION
## Prerequisites
N/A


## Task reference

https://github.com/rsms/inter/issues/128


## BREAKING CHANGES
N/A


## PR description

I was seeing inconsistent font spacing on the Honey framework ever since we switched from Roboto to Inter.

Then I saw (on this thread: https://github.com/rsms/inter/issues/128) that we can use `font-feature-settings: "tnum";`.

I thought it would be good to add it right here at the source.

## Example app screenshot
Nothing is changed on the example app since Source Sans pro displays numbers already in the same spacing. But here's the difference in the Honey framework:

Before:
![image](https://user-images.githubusercontent.com/13964126/121561745-d327c180-ca29-11eb-9776-1bbb6df4c260.png)

After:
![image](https://user-images.githubusercontent.com/13964126/121561999-15e99980-ca2a-11eb-8a1f-4a53f0b9f707.png)



## Storybook screenshot
N/A



## Checklist
  - [ ] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [ ] Added PR description
  - [ ] Relevant change in example app is verified, added example app screenshot
  - [ ] Storybook: stories, docs are updated/verified
  - [ ] `Pull request verify workflow` passed
  - [ ] PR development is completed, the developer is satisfied with the code quality and behavior of the app
