### PR TITLE
(improvement) Dropdown: add onSearchTermChange prop

### DIFF
--- a/packages/core/src/components/ui/Dropdown/Dropdown.List.js
+++ b/packages/core/src/components/ui/Dropdown/Dropdown.List.js
@@ -2,6 +2,7 @@ import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import cx from 'classnames'
 import _includes from 'lodash/includes'
+import _isEmpty from 'lodash/isEmpty'
 import _join from 'lodash/join'
 import _keys from 'lodash/keys'
 import _pickBy from 'lodash/pickBy'
@@ -25,7 +26,7 @@ const DropdownList = (props) => {
   const [searchTerm, setSearchTerm] = useState('')
 
   const filtered = useMemo(() => {
-    if (!searchable) {
+    if (!searchable || _isEmpty(searchValues)) {
       return options
     }
 

--- a/packages/core/src/components/ui/Dropdown/Dropdown.List.js
+++ b/packages/core/src/components/ui/Dropdown/Dropdown.List.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types'
 import React, { useState, useMemo } from 'react'
 
 import * as utils from '../../../common/utils'
+import { Button, Input } from '../index'
 
 const DropdownList = (props) => {
   const {
@@ -36,20 +37,20 @@ const DropdownList = (props) => {
 
   const keys = useMemo(() => _keys(filtered), [filtered])
 
-  const handleSearchTermClick = (e) => {
-    e.stopPropagation()
-    const { value: _v } = e.target
+  const updateSearchTerm = (_value) => {
     if (_isFunction(onSearchTermChange)) {
-      onSearchTermChange(_v)
+      onSearchTermChange(_value)
     }
-    setSearchTerm(_v)
+    setSearchTerm(_value)
+  }
+
+  const handleSearchTermChange = (_value, event) => {
+    event.stopPropagation()
+    updateSearchTerm(_value)
   }
 
   const onCancelClick = () => {
-    if (_isFunction(onSearchTermChange)) {
-      onSearchTermChange('')
-    }
-    setSearchTerm('')
+    updateSearchTerm('')
   }
 
   return (
@@ -57,15 +58,21 @@ const DropdownList = (props) => {
       {searchable && (
         <div className='list-search-wrapper'>
           <div className='list-search'>
-            <input
+            <Input
+              small
+              rightElement={searchTerm
+                ? (
+                  <Button onClick={onCancelClick} minimal>
+                    <FontAwesomeIcon icon={faTimes} className='search-icon' />
+                  </Button>
+                )
+                : <FontAwesomeIcon icon={faSearch} className='search-icon' />}
+              value={searchTerm}
+              className='search-ccy'
+              onChange={handleSearchTermChange}
               type='text'
               autoComplete='off'
-              value={searchTerm}
-              onChange={handleSearchTermClick}
             />
-            {searchTerm
-              ? <FontAwesomeIcon icon={faTimes} className='search-icon' onClick={onCancelClick} />
-              : <FontAwesomeIcon icon={faSearch} className='search-icon' />}
           </div>
         </div>
       )}

--- a/packages/core/src/components/ui/Dropdown/Dropdown.List.js
+++ b/packages/core/src/components/ui/Dropdown/Dropdown.List.js
@@ -1,4 +1,4 @@
-import { faSearch } from '@fortawesome/free-solid-svg-icons'
+import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import cx from 'classnames'
 import _includes from 'lodash/includes'
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 
 import * as utils from '../../../common/utils'
+import { Button } from '../index'
 
 const DropdownList = (props) => {
   const {
@@ -39,6 +40,8 @@ const DropdownList = (props) => {
     setSearchTerm(e.target.value)
   }
 
+  const onCancelClick = () => setSearchTerm('')
+
   return (
     <div className='list-wrapper'>
       {searchable && (
@@ -50,7 +53,9 @@ const DropdownList = (props) => {
               value={searchTerm}
               onChange={handleSearchTermClick}
             />
-            <FontAwesomeIcon className='search-icon' icon={faSearch} />
+            {searchTerm
+              ? <FontAwesomeIcon icon={faTimes} className='search-icon' onClick={onCancelClick} />
+              : <FontAwesomeIcon icon={faSearch} className='search-icon' />}
           </div>
         </div>
       )}

--- a/packages/core/src/components/ui/Dropdown/Dropdown.js
+++ b/packages/core/src/components/ui/Dropdown/Dropdown.js
@@ -19,13 +19,13 @@ const Dropdown = forwardRef(function Dropdown(props, ref) {
     id,
     name,
     searchable,
-    searchModifier,
     className,
     onChange,
     small,
     placeholder,
     closeOnMouseLeave,
     isOpen: isOpenProp,
+    searchValues,
     ...rest
   } = props
 
@@ -85,9 +85,9 @@ const Dropdown = forwardRef(function Dropdown(props, ref) {
             options={options}
             value={value}
             searchable={searchable}
-            searchModifier={searchModifier}
             optionRenderer={optionRenderer}
             onChange={handleOnChange}
+            searchValues={searchValues}
           />
         )}
       </div>
@@ -132,10 +132,7 @@ Dropdown.propTypes = {
    * If true, renders the dropdown with a search input.
    */
   searchable: PropTypes.bool,
-  /**
-   * The search input modifier function
-   */
-  searchModifier: PropTypes.func,
+  searchValues: PropTypes.objectOf(PropTypes.arrayOf),
   ...DropdownList.propTypes,
 }
 
@@ -149,7 +146,7 @@ Dropdown.defaultProps = {
   closeOnMouseLeave: false,
   isOpen: false,
   searchable: false,
-  searchModifier: null,
+  searchValues: null,
   ...DropdownList.defaultProps,
 }
 

--- a/packages/core/src/components/ui/Dropdown/Dropdown.js
+++ b/packages/core/src/components/ui/Dropdown/Dropdown.js
@@ -25,7 +25,7 @@ const Dropdown = forwardRef(function Dropdown(props, ref) {
     placeholder,
     closeOnMouseLeave,
     isOpen: isOpenProp,
-    searchValues,
+    onSearchTermChange,
     ...rest
   } = props
 
@@ -87,7 +87,7 @@ const Dropdown = forwardRef(function Dropdown(props, ref) {
             searchable={searchable}
             optionRenderer={optionRenderer}
             onChange={handleOnChange}
-            searchValues={searchValues}
+            onSearchTermChange={onSearchTermChange}
           />
         )}
       </div>
@@ -132,7 +132,7 @@ Dropdown.propTypes = {
    * If true, renders the dropdown with a search input.
    */
   searchable: PropTypes.bool,
-  searchValues: PropTypes.objectOf(PropTypes.arrayOf),
+  onSearchTermChange: PropTypes.func,
   ...DropdownList.propTypes,
 }
 
@@ -146,7 +146,7 @@ Dropdown.defaultProps = {
   closeOnMouseLeave: false,
   isOpen: false,
   searchable: false,
-  searchValues: null,
+  onSearchTermChange: null,
   ...DropdownList.defaultProps,
 }
 

--- a/packages/core/src/components/ui/Dropdown/_Dropdown.scss
+++ b/packages/core/src/components/ui/Dropdown/_Dropdown.scss
@@ -132,6 +132,7 @@ $ufx-dropdown-input-border: 1px solid $light-gray1 !default;
       right: $ufx-dropdown-padding * 0.5;
       height: 100%;
       color: $ufx-dropdown-text-color;
+      margin: 0;
     }
   }
 

--- a/packages/core/src/components/ui/Dropdown/stories/Dropdown.stories.js
+++ b/packages/core/src/components/ui/Dropdown/stories/Dropdown.stories.js
@@ -18,16 +18,6 @@ const props = {
     UNI: 'Uniswap',
   },
   value: 'BTC',
-  searchValues: {
-    BTC: ['Bitcoin', 'BTC'],
-    ETH: ['Ethereum', 'ETH'],
-    USDT: ['Tether', 'USDT'],
-    ADA: ['Cardano', 'ADA'],
-    DOGE: ['Dogecoin', 'DOGE'],
-    XRP: ['XRP'],
-    DOT: ['Polkadot', 'DOT'],
-    UNI: ['Uniswap', 'UNI'],
-  },
 }
 
 export const basic = showTemplateStory(Dropdown, props)

--- a/packages/core/src/components/ui/Dropdown/stories/Dropdown.stories.js
+++ b/packages/core/src/components/ui/Dropdown/stories/Dropdown.stories.js
@@ -18,6 +18,16 @@ const props = {
     UNI: 'Uniswap',
   },
   value: 'BTC',
+  searchValues: {
+    BTC: ['Bitcoin', 'BTC'],
+    ETH: ['Ethereum', 'ETH'],
+    USDT: ['Tether', 'USDT'],
+    ADA: ['Cardano', 'ADA'],
+    DOGE: ['Dogecoin', 'DOGE'],
+    XRP: ['XRP'],
+    DOT: ['Polkadot', 'DOT'],
+    UNI: ['Uniswap', 'UNI'],
+  },
 }
 
 export const basic = showTemplateStory(Dropdown, props)


### PR DESCRIPTION
## Prerequisites
https://github.com/bitfinexcom/bfx-hf-ui/pull/496

(If the PR requires any other PRs to be applied first, indicate it here, otherwise put "N/A")


## Task reference
https://app.asana.com/0/1125859137800433/1200488045717326

## BREAKING CHANGES
Need to pass `searchValues` (object) prop with all searching values to be able to search

(Explain here, any breaking changes that do not have backward compatibility with previous versions of ufx-ui or keep N/A
i.e. if you renamed some component prop. Someone who is using previous version, should work on these updates, before upating their `ufx-ui` dependency to this version)


## PR description
If input field is filled it is showing cancel button
Now user can search ccy pairs by their full names
Prop `searchModifier` is replaced from prop to fn out of component



## Example app screenshot
![Снимок экрана от 2021-06-17 23-25-58](https://user-images.githubusercontent.com/81973123/122540219-1806b600-d031-11eb-835d-f15755f7c1f9.png)
![Снимок экрана от 2021-06-18 11-35-04](https://user-images.githubusercontent.com/81973123/122540221-189f4c80-d031-11eb-9fa2-67373bf6907f.png)




## Storybook screenshot
N/A

(Add storybook screenshot if applicable, otherwise put "N/A")



## Checklist
  - [x] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [x] Relevant change in example app is verified, added example app screenshot
  - [x] Storybook: stories, docs are updated/verified
  - [x] `Pull request verify workflow` passed
  - [x] PR development is completed, the developer is satisfied with the code quality and behavior of the app
