### PR TITLE
(improvement): Dynamic VirtualTable width

### DIFF
--- a/packages/core/src/components/ui/VirtualTable/VirtualTable.helpers.js
+++ b/packages/core/src/components/ui/VirtualTable/VirtualTable.helpers.js
@@ -1,5 +1,7 @@
 import _get from 'lodash/get'
 import _isFunction from 'lodash/isFunction'
+import _map from 'lodash/map'
+import _reduce from 'lodash/reduce'
 
 export const getTransformers = (columns = []) => {
   const transformers = {}
@@ -89,4 +91,22 @@ export function sortData(args = {}, props = {}) {
   sortedDataPostProcessor(sortedData)
 
   return sortedData
+}
+
+/**
+ * Returns columns array based on the provided columnts and container width.
+ * Columns width are updated proportionally based on the container width and column's width.
+ *
+ * @param {number} containerWidth - the width of the container which contains table, columns will be relative to it
+ * @param {Array} columns - an array of columns to process
+ * @return {Array} updated columns array
+ */
+export const processColumns = (containerWidth, columns) => {
+  const sigma = _reduce(columns, (prev, curr) => prev + curr.width, 0)
+  const c = containerWidth / sigma
+
+  return _map(columns, (col) => ({
+    ...col,
+    width: col.width * c,
+  }))
 }


### PR DESCRIPTION
## Prerequisites
N/A

## Task reference
[column width on table component need to be relative](https://app.asana.com/0/1125859137800433/1200383864759508/f)

## BREAKING CHANGES
N/A

## PR description
In this PR I added a new boolean property to VirtualTable: `relational`.
Using this property adds ability for the table to have a relational columns width instead of the fixed one.
The prop is optional and by default is `false`, thus making it fully backward compatible.

Also the `processColumns` function has been added. It implements ability to 'upscale' the table width by saving the original column proportions (width are specified as 'width' column param).

## Example app screenshot
N/A

## Storybook screenshot

https://user-images.githubusercontent.com/35810911/122751840-cacc5380-d27f-11eb-9ce5-c832d7add986.mp4

## Checklist
  - [x] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [x] Relevant change in example app is verified, added example app screenshot
  - [x] Storybook: stories, docs are updated/verified
  - [x] `Pull request verify workflow` passed
  - [x] PR development is completed, the developer is satisfied with the code quality and behavior of the app
