### PR TITLE
(fix) orderform: remove max price limit when creating sell order with price > 10% of top ask price

### DIFF
--- a/packages/bfx-containers/src/containers/OrderForm/OrderForm.helpers.js
+++ b/packages/bfx-containers/src/containers/OrderForm/OrderForm.helpers.js
@@ -24,7 +24,7 @@ export const validatePrice = (isBuy, price, topAsk, topBid) => {
   const isSell = !isBuy
 
   const topAskMax = topAsk * 1.1
-  if (price > topAskMax) {
+  if (!isSell && price > topAskMax) {
     errors.push(i18n.t('orderform:buy_price_out_of_range', { maxPrice: setSigFig(topAskMax), priceDeltaPercent: 10 }))
   }
 


### PR DESCRIPTION
## Prerequisites
N/A

(If the PR requires any other PRs to be applied first, indicate it here, otherwise put "N/A")


## Task reference


## BREAKING CHANGES
N/A


## PR description
When creating sell order, it gives error when price > 10% of top ask price. Removed this check for sell order as it only makes sense for buy order



## Example app screenshot
N/A

(Add example app screenshot if applicable, otherwise put "N/A")



## Storybook screenshot
N/A

(Add storybook screenshot if applicable, otherwise put "N/A")



## Checklist
  - [X] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [X] Added PR description
  - [X] Relevant change in example app is verified, added example app screenshot
  - [X] Storybook: stories, docs are updated/verified
  - [X] `Pull request verify workflow` passed
  - [X] PR development is completed, the developer is satisfied with the code quality and behavior of the app
