### PR TITLE
(fix) Checkbox: showing cursor: help only if helpMessage is existed

### DIFF
--- a/packages/core/src/components/ui/Checkbox/Checkbox.js
+++ b/packages/core/src/components/ui/Checkbox/Checkbox.js
@@ -76,7 +76,7 @@ const Checkbox = forwardRef(function Checkbox(props, ref) {
 
       <Label
         label={label || ''}
-        className={cx({ disabled })}
+        className={cx({ disabled, 'label-help': Boolean(helpMessage) })}
         tag='div'
         small={small}
       />

--- a/packages/core/src/components/ui/Checkbox/_Checkbox.scss
+++ b/packages/core/src/components/ui/Checkbox/_Checkbox.scss
@@ -62,6 +62,10 @@ $checkbox-label-margin: 0 ($ufx-base-size * 0.5) 0 ($ufx-base-size * 2.5) !defau
     @include disabled();
   }
 
+  .label-help {
+    cursor: help;
+  }
+
   .error {
     @include error-base();
     align-self: baseline;

--- a/packages/core/src/components/ui/Checkbox/_Checkbox.scss
+++ b/packages/core/src/components/ui/Checkbox/_Checkbox.scss
@@ -58,7 +58,7 @@ $checkbox-label-margin: 0 ($ufx-base-size * 0.5) 0 ($ufx-base-size * 2.5) !defau
   .#{$ns}-label {
     display: flex;
     margin: $checkbox-label-margin;
-    cursor: help;
+    cursor: pointer;
     @include disabled();
   }
 


### PR DESCRIPTION
## Prerequisites
https://github.com/bitfinexcom/bfx-hf-ui/pull/523

(If the PR requires any other PRs to be applied first, indicate it here, otherwise put "N/A")


## Task reference
https://github.com/bitfinexcom/bfx-hf-ui/pull/523#pullrequestreview-709430460

## BREAKING CHANGES
N/A

(Explain here, any breaking changes that do not have backward compatibility with previous versions of ufx-ui or keep N/A
i.e. if you renamed some component prop. Someone who is using previous version, should work on these updates, before upating their `ufx-ui` dependency to this version)


## PR description
Checkbox: property cursor:help only if checkbox has helping message



## Example app screenshot
N/A

(Add example app screenshot if applicable, otherwise put "N/A")



## Storybook screenshot
N/A

(Add storybook screenshot if applicable, otherwise put "N/A")



## Checklist
  - [x] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [x] Relevant change in example app is verified, added example app screenshot
  - [x] Storybook: stories, docs are updated/verified
  - [x] `Pull request verify workflow` passed
  - [x] PR development is completed, the developer is satisfied with the code quality and behavior of the app
