### PR TITLE
(fix) Dialog: provide fallbackFocus to FocusTrap to avoid crash when no tabbable node

### DIFF
--- a/packages/core/src/components/ui/Dialog/Dialog.Modal.js
+++ b/packages/core/src/components/ui/Dialog/Dialog.Modal.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import React, { forwardRef } from 'react'
 
 import * as Classes from '../../../common/classes'
+import { DIALOG_CONTAINER_ID } from './Dialog.constants'
 
 const Modal = forwardRef(({
   state,
@@ -21,7 +22,11 @@ const Modal = forwardRef(({
   textAlign,
 }, ref) => (
   /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-  <FocusTrap>
+  <FocusTrap
+    focusTrapOptions={{
+      fallbackFocus: document.getElementById(DIALOG_CONTAINER_ID),
+    }}
+  >
     <div className={cx(Classes.DIALOG)}>
       <div
         className={cx('background', state, {

--- a/packages/core/src/components/ui/Dialog/Dialog.Wrapper.js
+++ b/packages/core/src/components/ui/Dialog/Dialog.Wrapper.js
@@ -4,6 +4,7 @@ import { Transition } from 'react-transition-group'
 
 import * as Classes from '../../../common/classes'
 import Portal from '../Portal'
+import { DIALOG_CONTAINER_ID } from './Dialog.constants'
 import Modal from './Dialog.Modal'
 
 // eslint-disable-next-line prefer-arrow-callback
@@ -45,7 +46,7 @@ const Dialog = forwardRef(function Dialog(props, ref) {
   }, [isOpen])
 
   return (
-    <Portal ref={ref} id='dialog-container' target={document.body}>
+    <Portal ref={ref} id={DIALOG_CONTAINER_ID} target={document.body}>
       <Transition
         in={isOpen}
         timeout={300}

--- a/packages/core/src/components/ui/Dialog/Dialog.constants.js
+++ b/packages/core/src/components/ui/Dialog/Dialog.constants.js
@@ -1,0 +1,2 @@
+/* eslint-disable import/prefer-default-export */
+export const DIALOG_CONTAINER_ID = 'dialog-container'


### PR DESCRIPTION
## Prerequisites
N/A


## Task reference


## BREAKING CHANGES
N/A


## PR description
focus-trap fails with error for following case
Since we are using Transition comp, initially it will render `.ufx-dialog` node with style="display: none". there is a isHidden check in `tabbable/dist/index.esm.js` which sets tabbable nodes to 0 and hence we get error even though there are focusable nodes in children prop. As a solution provide `fallbackFocus` prop



## Example app screenshot
N/A




## Storybook screenshot
N/A




## Checklist
  - [X] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [X] Added PR description
  - [X] Relevant change in example app is verified, added example app screenshot
  - [X] Storybook: stories, docs are updated/verified
  - [x] `Pull request verify workflow` passed
  - [X] PR development is completed, the developer is satisfied with the code quality and behavior of the app
