### PR TITLE
(refactor) checkbox: remove help message props

### DIFF
--- a/packages/core/src/components/ui/Checkbox/Checkbox.js
+++ b/packages/core/src/components/ui/Checkbox/Checkbox.js
@@ -1,12 +1,10 @@
 import cx from 'classnames'
-import _isEmpty from 'lodash/isEmpty'
 import PropTypes from 'prop-types'
 import React, { useRef, forwardRef } from 'react'
 
 import * as Classes from '../../../common/classes'
 import * as utils from '../../../common/utils'
 import Label from '../Label'
-import Tooltip from '../Tooltip'
 
 const stopPropagationOnClick = (e) => e.stopPropagation()
 
@@ -22,8 +20,6 @@ const Checkbox = forwardRef(function Checkbox(props, ref) {
     onChange,
     error,
     small,
-    helpMessage,
-    helpMessageClassName,
     ...rest
   } = props
   const checkboxRef = useRef(null)
@@ -58,7 +54,7 @@ const Checkbox = forwardRef(function Checkbox(props, ref) {
     ref: checkboxRef,
   }
 
-  const component = (
+  return (
     <div
       ref={ref}
       className={classes}
@@ -76,7 +72,7 @@ const Checkbox = forwardRef(function Checkbox(props, ref) {
 
       <Label
         label={label || ''}
-        className={cx({ disabled, 'label-help': Boolean(helpMessage) })}
+        className={cx({ disabled })}
         tag='div'
         small={small}
       />
@@ -88,16 +84,6 @@ const Checkbox = forwardRef(function Checkbox(props, ref) {
       )}
     </div>
   )
-
-  if (!_isEmpty(helpMessage)) {
-    return (
-      <Tooltip className={helpMessageClassName} content={helpMessage}>
-        {component}
-      </Tooltip>
-    )
-  }
-
-  return component
 })
 
 Checkbox.propTypes = {
@@ -137,14 +123,6 @@ Checkbox.propTypes = {
    * If true, shows the Button in a small style.
    */
   small: PropTypes.bool,
-  /**
-   * A help message to be shown in the tooltip.
-   */
-  helpMessage: PropTypes.string,
-  /**
-   * A classname for the tooltip with help message.
-   */
-  helpMessageClassName: PropTypes.string,
 }
 
 Checkbox.defaultProps = {
@@ -156,8 +134,6 @@ Checkbox.defaultProps = {
   onChange: () => { },
   error: '',
   small: false,
-  helpMessage: '',
-  helpMessageClassName: '',
 }
 
 export default Checkbox

--- a/packages/core/src/components/ui/Checkbox/_Checkbox.scss
+++ b/packages/core/src/components/ui/Checkbox/_Checkbox.scss
@@ -62,10 +62,6 @@ $checkbox-label-margin: 0 ($ufx-base-size * 0.5) 0 ($ufx-base-size * 2.5) !defau
     @include disabled();
   }
 
-  .label-help {
-    cursor: help;
-  }
-
   .error {
     @include error-base();
     align-self: baseline;


### PR DESCRIPTION
## Prerequisites


## Task reference
Checkbox


## BREAKING CHANGES
Checkbox: removed helpMessage, helpMessageClassName props 

## PR description
Removed help message props as checkbox `label` prop could be node type, so instead of separate help props, can pass label prop with Tooltip wrapper


## Example app screenshot
N/A

(Add example app screenshot if applicable, otherwise put "N/A")



## Storybook screenshot
N/A

(Add storybook screenshot if applicable, otherwise put "N/A")



## Checklist
  - [ ] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [ ] Added PR description
  - [ ] Relevant change in example app is verified, added example app screenshot
  - [ ] Storybook: stories, docs are updated/verified
  - [ ] `Pull request verify workflow` passed
  - [ ] PR development is completed, the developer is satisfied with the code quality and behavior of the app
