### PR TITLE
(improvement) unsubscribe prev symbol related channels on ticker change

### DIFF
--- a/packages/bfx-containers/src/redux/sagas/ws.saga.js
+++ b/packages/bfx-containers/src/redux/sagas/ws.saga.js
@@ -1,9 +1,10 @@
 import { logger } from '@ufx-ui/utils'
+import _forEach from 'lodash/forEach'
 import _get from 'lodash/get'
 import _isArray from 'lodash/isArray'
 import _isObject from 'lodash/isObject'
 import {
-  put, select, takeEvery, delay, fork, call,
+  put, select, takeEvery, delay, fork, call, all,
 } from 'redux-saga/effects'
 
 import {
@@ -17,7 +18,8 @@ import types, { WS_EVENT_TYPES } from '../constants/ws.constants'
 import {
   getWSConnected,
   getWSChannels,
-  findMatchingChannel,
+  findAllMatchingChannels,
+  findMatchingChannelWithSymbol,
 } from '../selectors/ws.selectors'
 import { wss, isHB } from './ws.saga.helpers'
 
@@ -80,9 +82,25 @@ function* processWSMessage({ payload: actionPayload }) {
   return null
 }
 
-function* unsubscibeChannel({ payload }) {
+function* unsubscibeChannel({ payload }, unsubscribeAll = false) {
   const channels = yield select(getWSChannels)
-  const channel = findMatchingChannel(channels, payload)
+  if (unsubscribeAll) {
+    const channelsToUnsubscribe = findAllMatchingChannels(channels, payload)
+
+    const actions = []
+    _forEach(channelsToUnsubscribe, (_channel) => {
+      const id = _get(_channel, 'chanId')
+
+      actions.push(put(WSSend({
+        event: WS_EVENT_TYPES.UNSUBSCRIBE,
+        chanId: id,
+      })))
+      actions.push(put(resetChannelState(_channel)))
+    })
+    yield all(actions)
+  }
+
+  const channel = findMatchingChannelWithSymbol(channels, payload)
   const chanId = _get(channel, 'chanId')
 
   if (!chanId) {
@@ -106,9 +124,9 @@ function* subscibeChannel({ payload }) {
   }))
 }
 
-function* resubscibeChannel({ payload }) {
-  // unsubscibe if already subscibed to channel
-  yield call(unsubscibeChannel, { payload })
+function* resubscibeChannel({ payload }, unsubscribeAll = true) {
+  // unsubscibe all channels or channel matching payload
+  yield call(unsubscibeChannel, { payload }, unsubscribeAll)
 
   yield put(WSSend({
     event: WS_EVENT_TYPES.SUBSCRIBE,

--- a/packages/bfx-containers/src/redux/selectors/book-top.selectors.js
+++ b/packages/bfx-containers/src/redux/selectors/book-top.selectors.js
@@ -8,7 +8,7 @@ import { createSelector } from 'reselect'
 import { BOOK_TOP_SUBSCRIPTION_CONFIG } from '../constants/book.constants'
 import { getTotals } from './book.selectors'
 import { getUfxState } from './common'
-import { getWSChannels, findMatchingChannel } from './ws.selectors'
+import { getWSChannels, findMatchingChannelWithSymbol } from './ws.selectors'
 
 const EMPTY_OBJ = {}
 
@@ -19,7 +19,7 @@ export const getBookTopChannel = createSelector(
     getWSChannels,
     (_, symbol) => symbol,
   ],
-  (wsChannels, symbol) => findMatchingChannel(wsChannels, {
+  (wsChannels, symbol) => findMatchingChannelWithSymbol(wsChannels, {
     ...BOOK_TOP_SUBSCRIPTION_CONFIG,
     symbol,
   }),

--- a/packages/bfx-containers/src/redux/selectors/book.selectors.js
+++ b/packages/bfx-containers/src/redux/selectors/book.selectors.js
@@ -6,7 +6,7 @@ import { createSelector } from 'reselect'
 
 import { SUBSCRIPTION_CONFIG } from '../constants/book.constants'
 import { getUfxState } from './common'
-import { getWSChannels, findMatchingChannel } from './ws.selectors'
+import { getWSChannels, findMatchingChannelWithSymbol } from './ws.selectors'
 
 const EMPTY_OBJ = {}
 
@@ -17,7 +17,7 @@ export const getBookChannel = createSelector(
     getWSChannels,
     (_, symbol) => symbol,
   ],
-  (wsChannels, symbol) => findMatchingChannel(wsChannels, {
+  (wsChannels, symbol) => findMatchingChannelWithSymbol(wsChannels, {
     ...SUBSCRIPTION_CONFIG,
     symbol,
   }),

--- a/packages/bfx-containers/src/redux/selectors/trades.selectors.js
+++ b/packages/bfx-containers/src/redux/selectors/trades.selectors.js
@@ -5,7 +5,7 @@ import { createSelector } from 'reselect'
 
 import { SUBSCRIPTION_CONFIG } from '../constants/trades.constants'
 import { getUfxState } from './common'
-import { getWSChannels, findMatchingChannel } from './ws.selectors'
+import { getWSChannels, findMatchingChannelWithSymbol } from './ws.selectors'
 
 const EMPTY_OBJ = {}
 
@@ -16,7 +16,7 @@ export const getTradesChannel = createSelector(
     getWSChannels,
     (_, symbol) => symbol,
   ],
-  (wsChannels, symbol) => findMatchingChannel(wsChannels, {
+  (wsChannels, symbol) => findMatchingChannelWithSymbol(wsChannels, {
     ...SUBSCRIPTION_CONFIG,
     symbol,
   }),

--- a/packages/bfx-containers/src/redux/selectors/ws.selectors.js
+++ b/packages/bfx-containers/src/redux/selectors/ws.selectors.js
@@ -1,3 +1,4 @@
+import _filter from 'lodash/filter'
 import _find from 'lodash/find'
 import _findKey from 'lodash/findKey'
 import _get from 'lodash/get'
@@ -36,7 +37,7 @@ export const getWSIsAuthenticated = createSelector(
   getWSAuthChannel, (authChannel) => (authChannel || EMPTY_OBJ).status === 'OK',
 )
 
-export const findMatchingChannel = (channels, source) => {
+export const findMatchingChannelWithSymbol = (channels, source) => {
   const compareWith = {
     symbol: source.symbol, // symbol: tBTCUSD
     channel: source.channel, // channel-name: book, trades
@@ -44,6 +45,15 @@ export const findMatchingChannel = (channels, source) => {
   }
 
   return _find(channels, _matches(compareWith))
+}
+
+export const findAllMatchingChannels = (channels, source) => {
+  const compareWith = {
+    channel: source.channel, // channel-name: book, trades
+    ...(source.len && { len: source.len }), // compare length because book and book-top has same name 'book' and differs by length, TODO: can we rename book(len=100) to book-top ?
+  }
+
+  return _filter(channels, _matches(compareWith))
 }
 
 export default {


### PR DESCRIPTION
## Prerequisites


## Task reference
[Trading: unsubscribe unused channels](https://app.asana.com/0/1189676765887416/1200630633941013/f)

## BREAKING CHANGES
WSResubscribeChannel: by default, it will first unsubscribe all relevant channels before subscribing for new symbol

## PR description




## Example app screenshot


<img width="1421" alt="Screenshot 2021-11-25 at 5 59 59 PM" src="https://user-images.githubusercontent.com/29878604/143442070-4ade8203-7233-47cb-a3a0-500bd0073ed6.png">

## Storybook screenshot
N/A

(Add storybook screenshot if applicable, otherwise put "N/A")



## Checklist
  - [X] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [X] Added PR description
  - [X] Relevant change in example app is verified, added example app screenshot
  - [X] Storybook: stories, docs are updated/verified
  - [X] `Pull request verify workflow` passed
  - [X] PR development is completed, the developer is satisfied with the code quality and behavior of the app
