### PR TITLE
(fix) Dialog: added isFocusTrapEnabled prop

### DIFF
--- a/packages/core/src/components/ui/Dialog/Dialog.Modal.js
+++ b/packages/core/src/components/ui/Dialog/Dialog.Modal.js
@@ -16,6 +16,7 @@ const Modal = forwardRef(({
   title,
   isFullscreenInMobile,
   hasStickyFooterInMobile,
+  isFocusTrapEnabled,
   children,
   width,
   height,
@@ -29,6 +30,7 @@ const Modal = forwardRef(({
         fallbackFocus: document.getElementById(DIALOG_CONTAINER_ID),
         initialFocus: titleRef.current,
       }}
+      active={isFocusTrapEnabled}
     >
       <div className={cx(Classes.DIALOG)}>
         <div
@@ -129,6 +131,11 @@ Modal.propTypes = {
 
   /** Determines the text alignment of the dialog */
   textAlign: PropTypes.oneOf(['left', 'center', 'right']),
+  /**
+   * If true, modal is using focus-trap library for better UX.
+   * Need to disable if modal contains iframe, to avoid conflicts
+   */
+  isFocusTrapEnabled: PropTypes.bool.isRequired,
 }
 
 Modal.defaultProps = {

--- a/packages/core/src/components/ui/Dialog/Dialog.Wrapper.js
+++ b/packages/core/src/components/ui/Dialog/Dialog.Wrapper.js
@@ -25,6 +25,7 @@ const Dialog = forwardRef(function Dialog(props, ref) {
     width,
     height,
     textAlign,
+    isFocusTrapEnabled,
   } = props
 
   useEffect(() => {
@@ -71,6 +72,7 @@ const Dialog = forwardRef(function Dialog(props, ref) {
             isCloseButtonShown={isCloseButtonShown}
             isFullscreenInMobile={isFullscreenInMobile}
             hasStickyFooterInMobile={hasStickyFooterInMobile}
+            isFocusTrapEnabled={isFocusTrapEnabled}
             onClose={onClose}
             width={width}
             height={height}
@@ -155,6 +157,11 @@ Dialog.propTypes = {
    * Determines the text alignment of the dialog
    */
   textAlign: PropTypes.oneOf(['left', 'center', 'right']),
+  /**
+   * If true, modal is using focus-trap library for better UX.
+   * Need to disable if modal contains iframe, to avoid conflicts
+   */
+  isFocusTrapEnabled: PropTypes.bool,
 }
 
 Dialog.defaultProps = {
@@ -165,6 +172,7 @@ Dialog.defaultProps = {
   canOutsideClickClose: true,
   isFullscreenInMobile: false,
   hasStickyFooterInMobile: false,
+  isFocusTrapEnabled: true,
   className: null,
   width: 460,
   height: 'auto',


### PR DESCRIPTION
## Prerequisites
https://github.com/bitfinexcom/bfx-hf-ui-core/pull/269

(If the PR requires any other PRs to be applied first, indicate it here, otherwise put "N/A")


## Task reference
https://app.asana.com/0/1200372033300327/1201714048308419

## BREAKING CHANGES
N/A

(Explain here, any breaking changes that do not have backward compatibility with previous versions of ufx-ui or keep N/A
i.e. if you renamed some component prop. Someone who is using previous version, should work on these updates, before upating their `ufx-ui` dependency to this version)


## PR description
added new prop isFocusTrapEnabled, to control enabling of FocusTrap component, because this one conflicts with iframe inside 



## Example app screenshot
N/A

(Add example app screenshot if applicable, otherwise put "N/A")




## Storybook screenshot
![Снимок экрана от 2022-02-04 14-42-28](https://user-images.githubusercontent.com/81973123/152531044-e1b425f4-7b1e-4b4c-9725-5c6a0c6188e5.png)

(Add storybook screenshot if applicable, otherwise put "N/A")



## Checklist
  - [x] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [x] Relevant change in example app is verified, added example app screenshot
  - [x] Storybook: stories, docs are updated/verified
  - [x] `Pull request verify workflow` passed
  - [x] PR development is completed, the developer is satisfied with the code quality and behavior of the app
