### PR TITLE
(feature) OrderHistory/VirtualTable: add callback to be invoked when fetching more rows

### DIFF
--- a/packages/core/src/components/OrderHistory/OrderHistory.js
+++ b/packages/core/src/components/OrderHistory/OrderHistory.js
@@ -28,6 +28,7 @@ export const OrderHistory = (props) => {
     rowMapping,
     className,
     isMobileLayout: isMobile,
+    loadMoreRows,
   } = props
   const { t } = useTranslation('orderhistory')
 
@@ -64,6 +65,7 @@ export const OrderHistory = (props) => {
         striped
         noRowsRenderer={noRowsRenderer(t)}
         minTableWidth={MIN_TABLE_WIDTH}
+        onScrollToBottom={loadMoreRows}
       />
     </div>
   )
@@ -92,6 +94,7 @@ OrderHistory.propTypes = {
    * breakpoint (BREAKPOINTS.SM).
    */
   isMobileLayout: PropTypes.bool,
+  loadMoreRows: PropTypes.func,
 }
 
 export const defaultProps = {
@@ -100,6 +103,7 @@ export const defaultProps = {
   rowMapping: {},
   className: null,
   isMobileLayout: undefined,
+  loadMoreRows: () => {},
 }
 
 OrderHistory.defaultProps = defaultProps

--- a/packages/core/src/components/ui/VirtualTable/VirtualTable.js
+++ b/packages/core/src/components/ui/VirtualTable/VirtualTable.js
@@ -35,6 +35,7 @@ const VirtualTable = (props) => {
     noRowsRenderer,
     minTableWidth,
     rowRenderer,
+    onScrollToBottom,
   } = props
   const [sortBy, setSortBy] = useState(defaultSortBy)
   const [sortDirection, setSortDirection] = useState(defaultSortDirection)
@@ -66,6 +67,17 @@ const VirtualTable = (props) => {
     setSortDirection(postSortDirection)
   }
 
+  const onScrollInternal = (message) => {
+    if (!message) {
+      return
+    }
+    const { clientHeight, scrollHeight, scrollTop } = message
+    const SCROLL_TO_BOTTOM_TRIGGER_THRESHOLD = 0
+    if ((clientHeight + scrollTop + SCROLL_TO_BOTTOM_TRIGGER_THRESHOLD) >= scrollHeight) {
+      onScrollToBottom()
+    }
+  }
+
   return (
     <div className={classes}>
       <div className={Classes.VIRTUAL_TABLE}>
@@ -78,6 +90,7 @@ const VirtualTable = (props) => {
                   ? minTableWidth
                   : width
               }
+              onScroll={onScrollInternal}
               rowHeight={rowHeight}
               rowGetter={({ index }) => _get(processedData, index)}
               rowCount={_size(processedData)}
@@ -214,6 +227,10 @@ VirtualTable.propTypes = {
    * The minimum width the table can shrink by
    */
   minTableWidth: PropTypes.number,
+  /**
+   * Callback to be invoked when more rows must be loaded
+   */
+  onScrollToBottom: PropTypes.func,
 }
 
 VirtualTable.defaultProps = {
@@ -233,6 +250,7 @@ VirtualTable.defaultProps = {
   noRowsRenderer: () => {},
   rowRenderer: defaultTableRowRenderer,
   minTableWidth: null,
+  onScrollToBottom: () => {},
 }
 
 export default memo(VirtualTable)


### PR DESCRIPTION


## Prerequisites
N/A

(If the PR requires any other PRs to be applied first, indicate it here, otherwise put "N/A")


## Task reference


## BREAKING CHANGES
N/A



## PR description
OrderHistory: add `loadMoreRows` prop: callback to be invoked when fetching more rows
VirtualTable: add `VirtualTable` prop: callback to be invoked when scrolling to bottom of table



## Example app screenshot
N/A

(Add example app screenshot if applicable, otherwise put "N/A")



## Storybook screenshot
N/A

(Add storybook screenshot if applicable, otherwise put "N/A")



## Checklist
  - [X] PR title has category name prefix, e.g. "\(fix\) {description}" (fix/feature/refactor/improvement/doc/test)
  - [x] Added PR description
  - [X] Relevant change in example app is verified, added example app screenshot
  - [X] Storybook: stories, docs are updated/verified
  - [X] `Pull request verify workflow` passed
  - [X] PR development is completed, the developer is satisfied with the code quality and behavior of the app
